### PR TITLE
Add getPath method to CmisObject

### DIFF
--- a/cms/v4/cmis.js
+++ b/cms/v4/cmis.js
@@ -249,7 +249,7 @@ function CmisObject() {
 	        return this.native.getPaths()[0];
 	    }
 
-		console.warn("Path for CmisObject not found");
+	    throw new Error(`Path not found for CmisObject with id ${this.getId()}`);
 	}
 
 	this.getType = function() {

--- a/cms/v4/cmis.js
+++ b/cms/v4/cmis.js
@@ -238,6 +238,20 @@ function CmisObject() {
 		return this.native.getName();
 	};
 
+	this.getPath = function() {
+		//this is caused by having different underlying native objects in different environments.
+	    if (this.native.getPath) {
+	        return this.native.getPath();
+	    }
+
+		//Apache Chemistry CmisObject has no getPath() but getPaths() - https://chemistry.apache.org/docs/cmis-samples/samples/retrieve-objects/index.html
+	    if (this.native.getPaths) {
+	        return this.native.getPaths()[0];
+	    }
+
+		console.warn("Path for CmisObject not found");
+	}
+
 	this.getType = function() {
 		var type = new TypeDefinition();
 		var native = this.native.getType();


### PR DESCRIPTION
We need path here because the resource *id* when using managed database provider is not its path while it is needed when checking constraints - https://chemistry.apache.org/docs/cmis-samples/samples/retrieve-objects/index.html So here we get different ids in different scenarios (local and managed).